### PR TITLE
added the missing r infront of the regex string

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ By default `obsidian tags` are just shown as bold text. Obsidian style can be ac
   padding: 5px;
   font-weight: normal;
 }
+
+[data-md-color-scheme="slate"] .hash {
+  background-color: #292433;
+}
 ```
 
 Activating this inside the mkdocs.yml

--- a/obsidian_support/conversion/tags.py
+++ b/obsidian_support/conversion/tags.py
@@ -6,7 +6,7 @@ a strategy that convert obsidian #tags (refer https://help.obsidian.md/Editing+a
 to **tags**{: .hash} (refer https://python-markdown.github.io/extensions/attr_list/) in markdown
 """
 
-OBSIDIAN_TAGS_REGEX = "(?<!\\)#(?P<tags>[\w\-_\/]+)(?![^\[\(`]*[\]\)`])"
+OBSIDIAN_TAGS_REGEX = r"(?<!\\)#(?P<tags>[\w\-_\/]+)(?![^\[\(`]*[\]\)`])"
 OBSIDIAN_TAGS_REGEX_GROUPS = ['tags']
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-VERSION_NUMBER = '0.8.0'
+VERSION_NUMBER = '0.8.1'
 
 
 def read_file(fname):


### PR DESCRIPTION
unfortunately there is an issue, so `mkdocs` crashs at startup. 
there is a missing r in front of the regex, as i realized.

btw: this will also fix the CI error on main branch.