### PR TITLE
Fix typo in image link doc

### DIFF
--- a/docs/features/image-link/index.md
+++ b/docs/features/image-link/index.md
@@ -6,7 +6,7 @@ comments: true
 > Convert `obsidian wikilink for images` to `mkdocs-material md-link for images`
 
 obsidian support [`wikilink`](https://help.obsidian.md/Linking+notes+and+files/Internal+links)
-with [embbe an image in a note](https://help.obsidian.md/Linking+notes+and+files/Embedding+files#Embed+an+image+in+a+note)
+with [embed an image in a note](https://help.obsidian.md/Linking+notes+and+files/Embedding+files#Embed+an+image+in+a+note)
 which is also known as `internal link`. However markdown and mkdocs-material does not support `wikilink`. It uses
 traditional [`markdown links`](https://squidfunk.github.io/mkdocs-material/reference/images/).
 


### PR DESCRIPTION
## Summary
- fix 'embbe' typo in docs/features/image-link

## Testing
- `pytest -q` *(fails: FileNotFoundError for markdown test data)*

------
https://chatgpt.com/codex/tasks/task_e_6843bdb17be88322be4d43b92059a07a