### PR TITLE
Fix overlap detection and add tests

### DIFF
--- a/obsidian_support/conversion/util.py
+++ b/obsidian_support/conversion/util.py
@@ -81,7 +81,7 @@ def get_exclude_indices(markdown: str) -> List[Tuple[int, int]]:
 
 
 def is_overlapped(start: int, end: int, exclude_indices_pairs: List[tuple]) -> bool:
-    for exclude_indices_pair in exclude_indices_pairs:
-        if exclude_indices_pair[0] <= start and end <= exclude_indices_pair[1]:
+    for exclude_start, exclude_end in exclude_indices_pairs:
+        if exclude_start < end and start < exclude_end:
             return True
     return False

--- a/test/conversion/test_util.py
+++ b/test/conversion/test_util.py
@@ -3,7 +3,7 @@ from typing import List
 
 from assertpy import assert_that
 
-from obsidian_support.conversion.util import get_exclude_indices
+from obsidian_support.conversion.util import get_exclude_indices, is_overlapped
 
 
 def test_get_exclude_indices_1():
@@ -236,3 +236,18 @@ def test_get_exclude_indices_7():
     # then
     assert_that(exclude_indices[0][0]).is_equal_to(markdown.index("<span "))
     assert_that(exclude_indices[0][1]).is_equal_to(markdown.index("</span>") + len("</span>"))
+
+
+def test_is_overlapped_partial_overlap_left():
+    pairs = [(10, 20)]
+    assert_that(is_overlapped(5, 15, pairs)).is_true()
+
+
+def test_is_overlapped_partial_overlap_right():
+    pairs = [(10, 20)]
+    assert_that(is_overlapped(15, 25, pairs)).is_true()
+
+
+def test_is_overlapped_boundary_touching():
+    pairs = [(10, 20)]
+    assert_that(is_overlapped(20, 25, pairs)).is_false()


### PR DESCRIPTION
## Summary
- update `is_overlapped` to detect any intersection
- unit test coverage for partial overlaps

## Testing
- `pytest test/conversion/test_util.py -q`
- `pytest -q` *(fails: FileNotFoundError for markdown samples)*

------
https://chatgpt.com/codex/tasks/task_e_6843bde8a3648322a4c7f44c995b2785